### PR TITLE
perf:调整appLifecycle的安装时机

### DIFF
--- a/app/src/main/java/com/petterp/floatingx/app/MainActivity.kt
+++ b/app/src/main/java/com/petterp/floatingx/app/MainActivity.kt
@@ -43,19 +43,21 @@ class MainActivity : AppCompatActivity() {
                         }.show()
                     }
                     addItemView("更新当前[全局浮窗1]内容-(传递view方式)") {
-                        FloatingX.control(MultipleFxActivity.TAG_1).updateView {
-                            TextView(it).apply {
-                                layoutParams = ViewGroup.LayoutParams(
-                                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                                    ViewGroup.LayoutParams.WRAP_CONTENT
-                                )
-                                text = "App"
-                                textSize = 15f
-                                setBackgroundColor(Color.GRAY)
-                                setPadding(10, 10, 10, 10)
+                        FloatingX.control(MultipleFxActivity.TAG_1).apply {
+                            updateView {
+                                TextView(it).apply {
+                                    layoutParams = ViewGroup.LayoutParams(
+                                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                                        ViewGroup.LayoutParams.WRAP_CONTENT
+                                    )
+                                    text = "App"
+                                    textSize = 15f
+                                    setBackgroundColor(Color.GRAY)
+                                    setPadding(10, 10, 10, 10)
+                                }
                             }
+                            show()
                         }
-                        FloatingX.control(MultipleFxActivity.TAG_1).show()
                     }
                     addItemView("显示一个Activity悬浮窗-(展示与多指触摸)") {
                         activityFx.show()

--- a/app/src/main/java/com/petterp/floatingx/app/MainActivity.kt
+++ b/app/src/main/java/com/petterp/floatingx/app/MainActivity.kt
@@ -40,7 +40,7 @@ class MainActivity : AppCompatActivity() {
                             this.updateViewContent {
                                 it.setText(R.id.tvItemFx, "App")
                             }
-                        }.show()
+                        }.show(this@MainActivity)
                     }
                     addItemView("更新当前[全局浮窗1]内容-(传递view方式)") {
                         FloatingX.control(MultipleFxActivity.TAG_1).apply {
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
                                     setPadding(10, 10, 10, 10)
                                 }
                             }
-                            show()
+                            show(this@MainActivity)
                         }
                     }
                     addItemView("显示一个Activity悬浮窗-(展示与多指触摸)") {

--- a/app/src/main/java/com/petterp/floatingx/app/MultipleFxActivity.kt
+++ b/app/src/main/java/com/petterp/floatingx/app/MultipleFxActivity.kt
@@ -16,33 +16,36 @@ class MultipleFxActivity : AppCompatActivity() {
         createLinearLayoutToParent {
             addNestedScrollView {
                 addLinearLayout {
-                    addItemView("显示全局悬浮窗-tag1") {
+                    addItemView("显示全局悬浮窗(tag1)") {
                         if (!FloatingX.isInstalled(TAG_1)) {
                             CustomKtApplication.installTag1(application)
                         }
                         FloatingX.control(TAG_1).show(this@MultipleFxActivity)
                     }
-                    addItemView("重复安装全局悬浮窗-tag1") {
-                        CustomKtApplication.installTag1(application)
-                        FloatingX.control(TAG_1).show(this@MultipleFxActivity)
-                    }
-                    addItemView("显示全局悬浮窗-tag2") {
+                    addItemView("显示全局悬浮窗(tag2)") {
                         if (!FloatingX.isInstalled(TAG_2)) {
                             CustomKtApplication.installTag2(application)
                         }
                         FloatingX.control(TAG_2).show(this@MultipleFxActivity)
                     }
-                    addItemView("隐藏全局悬浮窗-tag1") {
-                        FloatingX.control(TAG_1).hide()
+                    addItemView("重复安装全局悬浮窗(tag1)") {
+                        CustomKtApplication.installTag1(application)
+                        FloatingX.control(TAG_1).show(this@MultipleFxActivity)
                     }
-                    addItemView("隐藏全局悬浮窗-tag2") {
-                        FloatingX.control(TAG_2).hide()
+                    addItemView("隐藏全局悬浮窗(tag1)") {
+                        FloatingX.controlOrNull(TAG_1)?.hide()
                     }
-                    addItemView("卸载所有全局浮窗并清空配置") {
+                    addItemView("隐藏全局悬浮窗(tag2)") {
+                        FloatingX.controlOrNull(TAG_2)?.hide()
+                    }
+                    addItemView("关闭全局悬浮窗(tag1)") {
+                        FloatingX.controlOrNull(TAG_1)?.cancel()
+                    }
+                    addItemView("关闭全局悬浮窗(tag2)") {
+                        FloatingX.controlOrNull(TAG_2)?.cancel()
+                    }
+                    addItemView("卸载所有全局浮窗") {
                         FloatingX.uninstallAll()
-                        // 如果调用了FloatingX.release(),那么后续浮窗在该activity show()时就需要传递activity
-                        // 具体原因是install()浮窗时，会插入app-lifecycle监听，页面onResume()没再次调用时，FloatingX无法得知activity是什么？
-                        FloatingX.release()
                     }
                 }
             }

--- a/app/src/main/java/com/petterp/floatingx/app/MultipleFxActivity.kt
+++ b/app/src/main/java/com/petterp/floatingx/app/MultipleFxActivity.kt
@@ -20,13 +20,17 @@ class MultipleFxActivity : AppCompatActivity() {
                         if (!FloatingX.isInstalled(TAG_1)) {
                             CustomKtApplication.installTag1(application)
                         }
-                        FloatingX.control(TAG_1).show()
+                        FloatingX.control(TAG_1).show(this@MultipleFxActivity)
+                    }
+                    addItemView("重复安装全局悬浮窗-tag1") {
+                        CustomKtApplication.installTag1(application)
+                        FloatingX.control(TAG_1).show(this@MultipleFxActivity)
                     }
                     addItemView("显示全局悬浮窗-tag2") {
                         if (!FloatingX.isInstalled(TAG_2)) {
                             CustomKtApplication.installTag2(application)
                         }
-                        FloatingX.control(TAG_2).show()
+                        FloatingX.control(TAG_2).show(this@MultipleFxActivity)
                     }
                     addItemView("隐藏全局悬浮窗-tag1") {
                         FloatingX.control(TAG_1).hide()
@@ -34,8 +38,11 @@ class MultipleFxActivity : AppCompatActivity() {
                     addItemView("隐藏全局悬浮窗-tag2") {
                         FloatingX.control(TAG_2).hide()
                     }
-                    addItemView("卸载所有全局浮窗") {
+                    addItemView("卸载所有全局浮窗并清空配置") {
                         FloatingX.uninstallAll()
+                        // 如果调用了FloatingX.release(),那么后续浮窗在该activity show()时就需要传递activity
+                        // 具体原因是install()浮窗时，会插入app-lifecycle监听，页面onResume()没再次调用时，FloatingX无法得知activity是什么？
+                        FloatingX.release()
                     }
                 }
             }

--- a/app/src/main/java/com/petterp/floatingx/app/kotlin/CustomKtApplication.kt
+++ b/app/src/main/java/com/petterp/floatingx/app/kotlin/CustomKtApplication.kt
@@ -26,18 +26,18 @@ class CustomKtApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        FloatingX.install {
-            setLayout(R.layout.item_floating)
-
-            // 如果你全局 [只需要一个浮窗]，这里可以不用传递 tag，默认我们会使用 FX_DEFAULT_TAG 作为未传递TAG时的默认值
-            // 这样的好处是，后续调用控制器(FloatingX.control())时，不用传递 tag。因为相应的方法默认参数里已经携带了该tag
-            // 比如：FloatingX.control()、FloatingX.configControl()
-            // 注意：如果你重复调用install()方法，且未设置tag，那么新的浮窗将会覆盖旧的默认浮窗
-
-            // 注意：这里的tag是用来区分不同的浮窗的，如果你需要多个浮窗，那么请务必设置不同的tag
-            // 注意: 当你调用控制器时，必须传递对应的tag，否则将会抛出异常，除非你使用了 [可null] 的获取方法
-            setTag("ONE")
-        }
+//        FloatingX.install {
+//            setLayout(R.layout.item_floating)
+//
+//            // 如果你全局 [只需要一个浮窗]，这里可以不用传递 tag，默认我们会使用 FX_DEFAULT_TAG 作为未传递TAG时的默认值
+//            // 这样的好处是，后续调用控制器(FloatingX.control())时，不用传递 tag。因为相应的方法默认参数里已经携带了该tag
+//            // 比如：FloatingX.control()、FloatingX.configControl()
+//            // 注意：如果你重复调用install()方法，且未设置tag，那么新的浮窗将会覆盖旧的默认浮窗
+//
+//            // 注意：这里的tag是用来区分不同的浮窗的，如果你需要多个浮窗，那么请务必设置不同的tag
+//            // 注意: 当你调用控制器时，必须传递对应的tag，否则将会抛出异常，除非你使用了 [可null] 的获取方法
+//            setTag(MultipleFxActivity.TAG_1)
+//        }
 
         installTag1(this)
     }

--- a/floatingx/src/main/java/com/petterp/floatingx/assist/helper/BasisHelper.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/assist/helper/BasisHelper.kt
@@ -1,6 +1,5 @@
 package com.petterp.floatingx.assist.helper
 
-import android.content.Context
 import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
@@ -111,8 +110,6 @@ open class BasisHelper {
     }
 
     abstract class Builder<T, B : BasisHelper> {
-        private var context: Context? = null
-
         @LayoutRes
         private var layoutId: Int = 0
         private var layoutView: View? = null

--- a/floatingx/src/main/java/com/petterp/floatingx/assist/helper/ScopeHelper.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/assist/helper/ScopeHelper.kt
@@ -12,9 +12,9 @@ import com.petterp.floatingx.util.contentView
 class ScopeHelper : BasisHelper() {
 
     /** 插入到Activity中 */
-    fun toControl(activity: Activity): IFxScopeControl {
+    fun toControl(activity: Activity): IFxScopeControl<Activity> {
         initLog(FxScopeEnum.ACTIVITY_SCOPE.tag)
-        val control = initScopeControl()
+        val control = FxScopeControl<Activity>(this)
         activity.contentView?.let {
             control.setContainerGroup(it)
         } ?: fxLog?.e("install to Activity the Error,current contentView(R.id.content) = null!")
@@ -22,26 +22,24 @@ class ScopeHelper : BasisHelper() {
     }
 
     /** 插入到Fragment中 */
-    fun toControl(fragment: Fragment): IFxScopeControl {
+    fun toControl(fragment: Fragment): IFxScopeControl<Fragment> {
         initLog(FxScopeEnum.FRAGMENT_SCOPE.tag)
         val rootView = fragment.view as? FrameLayout
         checkNotNull(rootView) {
             "Check if your root layout is FrameLayout, or if the init call timing is after onCreateView()!"
         }
-        val control = initScopeControl()
+        val control = FxScopeControl<Fragment>(this)
         control.setContainerGroup(rootView)
         return control
     }
 
     /** 插入到ViewGroup中 */
-    fun toControl(group: FrameLayout): IFxScopeControl {
+    fun toControl(group: FrameLayout): IFxScopeControl<FrameLayout> {
         initLog(FxScopeEnum.VIEW_GROUP_SCOPE.tag)
-        val control = initScopeControl()
+        val control = FxScopeControl<FrameLayout>(this)
         control.setContainerGroup(group)
         return control
     }
-
-    private fun initScopeControl() = FxScopeControl(this)
 
     companion object {
         @JvmStatic

--- a/floatingx/src/main/java/com/petterp/floatingx/assist/helper/ScopeHelper.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/assist/helper/ScopeHelper.kt
@@ -4,25 +4,44 @@ import android.app.Activity
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import com.petterp.floatingx.impl.control.FxScopeControl
-import com.petterp.floatingx.listener.control.IFxControl
 import com.petterp.floatingx.listener.control.IFxScopeControl
+import com.petterp.floatingx.util.FxScopeEnum
+import com.petterp.floatingx.util.contentView
 
 /** 特定范围的Helper构建器 */
 class ScopeHelper : BasisHelper() {
 
     /** 插入到Activity中 */
-    fun toControl(activity: Activity): IFxControl =
-        toControl().init(activity)
+    fun toControl(activity: Activity): IFxScopeControl {
+        initLog(FxScopeEnum.ACTIVITY_SCOPE.tag)
+        val control = initScopeControl()
+        activity.contentView?.let {
+            control.setContainerGroup(it)
+        } ?: fxLog?.e("install to Activity the Error,current contentView(R.id.content) = null!")
+        return control
+    }
 
     /** 插入到Fragment中 */
-    fun toControl(fragment: Fragment): IFxControl =
-        toControl().init(fragment)
+    fun toControl(fragment: Fragment): IFxScopeControl {
+        initLog(FxScopeEnum.FRAGMENT_SCOPE.tag)
+        val rootView = fragment.view as? FrameLayout
+        checkNotNull(rootView) {
+            "Check if your root layout is FrameLayout, or if the init call timing is after onCreateView()!"
+        }
+        val control = initScopeControl()
+        control.setContainerGroup(rootView)
+        return control
+    }
 
     /** 插入到ViewGroup中 */
-    fun toControl(group: FrameLayout): IFxControl =
-        toControl().init(group)
+    fun toControl(group: FrameLayout): IFxScopeControl {
+        initLog(FxScopeEnum.VIEW_GROUP_SCOPE.tag)
+        val control = initScopeControl()
+        control.setContainerGroup(group)
+        return control
+    }
 
-    private fun toControl(): IFxScopeControl<IFxControl> = FxScopeControl(this)
+    private fun initScopeControl() = FxScopeControl(this)
 
     companion object {
         @JvmStatic

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxAppControlImpl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxAppControlImpl.kt
@@ -130,7 +130,7 @@ class FxAppControlImpl(
         // 重置之前记得移除insets
         clearWindowsInsetsListener()
         super.reset()
-        FloatingX.reset(helper.tag)
+        FloatingX.uninstall(helper.tag, this)
     }
 
     private fun clearWindowsInsetsListener() {

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxAppControlImpl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxAppControlImpl.kt
@@ -38,10 +38,11 @@ class FxAppControlImpl(
     }
 
     override fun show(activity: Activity) {
-        super.show()
         if (isShow()) return
         if (attach(activity)) {
             getManagerView()?.show()
+            updateEnableStatus(true)
+            FloatingX.checkAppLifecycleInstall()
         }
     }
 
@@ -67,16 +68,6 @@ class FxAppControlImpl(
     }
 
     override fun context(): Context = FloatingX.getContext()
-
-    /** 请注意： 调用此方法前请确定在初始化fx时,调用了show方法,否则,fx默认不会插入到全局Activity */
-    override fun show() {
-        if (topActivity == null) {
-            helper.enableFx = true
-            helper.fxLog?.e("show-fx, topActivity=null,Do not call it during initialization in Application!")
-            return
-        }
-        show(topActivity!!)
-    }
 
     private fun initWindowsInsetsListener() {
         getManagerView()?.let {

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxBasisControlImpl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxBasisControlImpl.kt
@@ -21,6 +21,7 @@ import java.lang.ref.WeakReference
 
 /** 基础控制器实现 */
 open class FxBasisControlImpl(private val helper: BasisHelper) : IFxControl, IFxConfigControl {
+    private var isClosing = false
     private var managerView: FxManagerView? = null
     private var viewHolder: FxViewHolder? = null
     private var mContainer: WeakReference<ViewGroup>? = null
@@ -37,7 +38,8 @@ open class FxBasisControlImpl(private val helper: BasisHelper) : IFxControl, IFx
     }
 
     override fun cancel() {
-        if (managerView == null && viewHolder == null) return
+        if ((managerView == null && viewHolder == null) || isClosing) return
+        isClosing = true
         if (helper.enableAnimation &&
             helper.fxAnimation != null
         ) {
@@ -259,7 +261,9 @@ open class FxBasisControlImpl(private val helper: BasisHelper) : IFxControl, IFx
         }
     }
 
+    @JvmSynthetic
     protected open fun reset() {
+        isClosing = false
         managerView?.removeCallbacks(hideAnimationRunnable)
         managerView?.removeCallbacks(cancelAnimationRunnable)
         detach(mContainer?.get())

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxScopeControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxScopeControl.kt
@@ -6,9 +6,9 @@ import com.petterp.floatingx.assist.helper.BasisHelper
 import com.petterp.floatingx.listener.control.IFxScopeControl
 
 /** Fx普通View控制器 */
-class FxScopeControl(helper: BasisHelper) :
+class FxScopeControl<T>(helper: BasisHelper) :
     FxBasisControlImpl(helper),
-    IFxScopeControl {
+    IFxScopeControl<T> {
 
     override fun show() {
         if (isShow()) return

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxScopeControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/control/FxScopeControl.kt
@@ -1,51 +1,21 @@
 package com.petterp.floatingx.impl.control
 
-import android.app.Activity
 import android.app.Application
 import android.view.View
-import android.widget.FrameLayout
-import androidx.fragment.app.Fragment
 import com.petterp.floatingx.assist.helper.BasisHelper
-import com.petterp.floatingx.listener.control.IFxControl
 import com.petterp.floatingx.listener.control.IFxScopeControl
-import com.petterp.floatingx.util.FxScopeEnum
-import com.petterp.floatingx.util.contentView
 
 /** Fx普通View控制器 */
-class FxScopeControl(private val helper: BasisHelper) :
+class FxScopeControl(helper: BasisHelper) :
     FxBasisControlImpl(helper),
-    IFxScopeControl<IFxControl> {
+    IFxScopeControl {
 
     override fun show() {
-        super.show()
         if (isShow()) return
         if (getManagerView() == null) initManagerView()
+        updateEnableStatus(true)
         getContainerGroup()?.addView(getManagerView())
         getManagerView()?.show()
-    }
-
-    override fun init(group: FrameLayout): IFxControl {
-        helper.initLog(FxScopeEnum.VIEW_GROUP_SCOPE.tag)
-        setContainerGroup(group)
-        return this
-    }
-
-    override fun init(fragment: Fragment): IFxControl {
-        helper.initLog(FxScopeEnum.FRAGMENT_SCOPE.tag)
-        val rootView = fragment.view as? FrameLayout
-        checkNotNull(rootView) {
-            "Check if your root layout is FrameLayout, or if the init call timing is after onCreateView()!"
-        }
-        setContainerGroup(rootView)
-        return this
-    }
-
-    override fun init(activity: Activity): IFxControl {
-        helper.initLog(FxScopeEnum.ACTIVITY_SCOPE.tag)
-        activity.contentView?.let {
-            setContainerGroup(it)
-        } ?: helper.fxLog?.e("install to Activity the Error,current contentView(R.id.content) = null!")
-        return this
     }
 
     override fun updateView(view: View) {

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleCallbackImpl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleCallbackImpl.kt
@@ -8,8 +8,7 @@ import com.petterp.floatingx.impl.control.FxAppControlImpl
 import java.lang.ref.WeakReference
 
 /** App-lifecycle-CallBack */
-class FxLifecycleCallbackImpl :
-    Application.ActivityLifecycleCallbacks {
+class FxLifecycleCallbackImpl : Application.ActivityLifecycleCallbacks {
 
     private val fxList: Collection<FxAppControlImpl>
         get() = FloatingX.getFxList().values
@@ -30,7 +29,7 @@ class FxLifecycleCallbackImpl :
 
     /** 最开始想到在onActivityPostStarted后插入, 但是最后发现在Android9及以下,此方法不会被调用,故选择了onResume */
     override fun onActivityResumed(activity: Activity) {
-        initTopActivity(activity)
+        updateTopActivity(activity)
         if (isFxsNotAllow()) return
         for (fx in fxList) {
             fx.onActivityResumed(activity)
@@ -73,7 +72,7 @@ class FxLifecycleCallbackImpl :
         return fxList.isEmpty()
     }
 
-    private fun initTopActivity(activity: Activity) {
+    private fun updateTopActivity(activity: Activity) {
         if (topActivity?.get() != activity) topActivity = WeakReference(activity)
     }
 
@@ -82,6 +81,12 @@ class FxLifecycleCallbackImpl :
 
         @JvmSynthetic
         fun getTopActivity(): Activity? = topActivity?.get()
+
+        @JvmSynthetic
+        internal fun updateTopActivity(activity: Activity?) {
+            if (activity == null) return
+            topActivity = WeakReference(activity)
+        }
 
         @JvmSynthetic
         internal fun releaseTopActivity() {

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleCallbackImpl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleCallbackImpl.kt
@@ -82,5 +82,11 @@ class FxLifecycleCallbackImpl :
 
         @JvmSynthetic
         fun getTopActivity(): Activity? = topActivity?.get()
+
+        @JvmSynthetic
+        internal fun releaseTopActivity() {
+            topActivity?.clear()
+            topActivity = null
+        }
     }
 }

--- a/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleProvider.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/impl/lifecycle/FxLifecycleProvider.kt
@@ -8,12 +8,13 @@ import com.petterp.floatingx.FloatingX
 
 /**
  * AppLifecycle全局绑定者
+ *
  * @author petterp
  */
 class FxLifecycleProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         context?.let {
-            FloatingX.initAppLifecycle(it)
+            FloatingX.initContext(it)
         }
         return true
     }

--- a/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxAppControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxAppControl.kt
@@ -4,8 +4,19 @@ import android.app.Activity
 
 /** App特有的控制方法 */
 interface IFxAppControl : IFxControl {
+
+    /**
+     * 在当前activity中显示浮窗
+     *
+     * @param activity 当前要显示浮窗的activity
+     *
+     * 第一次调用该方法时，我们会插入一个AppLifecycle，用于监听activity的变化。当后续浮窗被cancel()时，我们会根据浮窗个数(=0)，自动清空该lifecycle的绑定
+     *
+     * ps:尽管我们可以做到不传递activity，但是这种方式需要以性能作为牺牲，比如需要永久维护一个顶级activity与AppLifecycle监听器
+     */
     fun show(activity: Activity)
 
+    /** 从当前activity中移除 */
     fun detach(activity: Activity)
 
     /** 获得当前绑定的activity,不要手动保留此activity,以避免泄漏 */

--- a/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxControl.kt
@@ -13,18 +13,17 @@ interface IFxControl {
     /** 获取配置层控制器,以便运行时动态调整某些基础配置 */
     val configControl: IFxConfigControl
 
-    /** 显示悬浮窗 */
-    fun show()
-
     /** 隐藏悬浮窗-不会解绑app-lifecycle */
     fun hide()
 
-    /**
-     * 当前浮窗是否显示
-     */
+    /** 当前浮窗是否显示 */
     fun isShow(): Boolean
 
-    /** 关闭fx,并释放所有监听 在普通模式,这相当于干掉当前悬浮窗 在全局application,这等于只保留helper,移除其他所有监听 */
+    /**
+     * 关闭fx,并释放所有监听 在普通模式,这相当于干掉当前悬浮窗
+     *
+     * 在全局浮窗,如果当前浮窗个数为0时，我们将移除所有配置监听，比如取消AppLifecycle的订阅
+     */
     fun cancel()
 
     /** 获取正在显示的浮窗内容视图,即通过layoutId或者自定义View传递进来的 View */
@@ -33,9 +32,7 @@ interface IFxControl {
     /** 获取浮窗内容视图所对应的Holder */
     fun getViewHolder(): FxViewHolder?
 
-    /**
-     * 获取浮窗管理器view,即浮窗底层容器
-     */
+    /** 获取浮窗管理器view,即浮窗底层容器 */
     fun getManagerView(): FxManagerView?
 
     /** 用于快速刷新视图内容 */

--- a/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxScopeControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxScopeControl.kt
@@ -1,28 +1,7 @@
 package com.petterp.floatingx.listener.control
 
-import android.app.Activity
-import android.widget.FrameLayout
-import androidx.fragment.app.Fragment
-
-/**
- * Fx局部控制器
- */
-interface IFxScopeControl<T> {
-    /**
-     * 在FrameLayout中初始化
-     *@param group 根布局必须为[FrameLayout],以便fx正常插入
-     * */
-    fun init(group: FrameLayout): T
-
-    /**
-     * 在FrameLayout中初始化
-     *@param fragment 您Fragment根布局必须为[FrameLayout],否则将抛出异常
-     * */
-    fun init(fragment: Fragment): T
-
-    /**
-     * 在Activity中初始化
-     * @param activity 最终会插入到 R.id.content 中
-     * */
-    fun init(activity: Activity): T
+/** Fx局部控制器 */
+interface IFxScopeControl : IFxControl {
+    /** 显示浮窗 */
+    fun show()
 }

--- a/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxScopeControl.kt
+++ b/floatingx/src/main/java/com/petterp/floatingx/listener/control/IFxScopeControl.kt
@@ -1,7 +1,7 @@
 package com.petterp.floatingx.listener.control
 
 /** Fx局部控制器 */
-interface IFxScopeControl : IFxControl {
+interface IFxScopeControl<T> : IFxControl {
     /** 显示浮窗 */
     fun show()
 }


### PR DESCRIPTION
- 取消默认ContentProvider的初始化applifecycle，延迟到install()中；
- 新增 FloatingX.release() 用于解绑注册的appLifecycle
- fix：修复了多浮窗install()时，因为动画时机导致的tag移除异常情况；
- fix:   修复浮窗隐藏时，cancel() 在有动画的情况下未生效