### PR TITLE
build: update Java version in CI configuration from 11 to 17

### DIFF
--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
 
       - uses: burrunan/gradle-cache-action@v3


### PR DESCRIPTION
## Sourcery 总结

CI:
- 在 publish_maven GitHub Actions 工作流中将 Java 版本从 11 升级到 17

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Upgrade Java version from 11 to 17 in the publish_maven GitHub Actions workflow

</details>