### PR TITLE
build:调整ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,23 +14,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
+
       - uses: burrunan/gradle-cache-action@v3
         name: Cache gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-#      - name: Detekt Code Style
-#        continue-on-error: true
-#        run: ./gradlew clean detekt
-#
-#      - name: Upload SARIF to Github using the upload-sarif action
-#        continue-on-error: true
-#        uses: github/codeql-action/upload-sarif@v3
-#        if: success() || failure()
-#        with:
-#          sarif_file: ${{ github.workspace }}/app/build/reports/detekt/detekt.sarif
-#          checkout_path: ${{ github.workspace }}
-
-      - name: Build with Gradle
-        run: ./gradlew publishToMavenLocal -PisPublish=false -PversionName=1.0
+      - name: publish maven
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USER_NAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASS_WORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY}}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASS_WORD }}
+        run: ./gradlew publishToMavenCentral --no-configuration-cache -PisPublish=true -PversionName=2.3.5.1

--- a/build.gradle
+++ b/build.gradle
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.android.lirary) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    id 'signing'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,5 +8,4 @@ plugins {
     alias(libs.plugins.android.lirary) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
-    id 'signing'
 }


### PR DESCRIPTION
…onment variables

## Sourcery 总结

配置 Android CI 以将制品发布到 Maven Central 并进行 GPG 签名，移除未使用的 Detekt/SARIF 步骤，并在构建中启用签名插件。

构建:
- 在 build.gradle 中添加 'signing' Gradle 插件以启用制品签名。

CI:
- 将本地 Maven 发布步骤替换为使用 Maven Central 凭据和 GPG 签名的 Gradle `publishToMavenCentral`，并将版本提升至 2.3.5.1。
- 从 CI 工作流中移除被注释掉的 Detekt lint 和 SARIF 上传操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Android CI to publish artifacts to Maven Central with GPG signing, remove unused Detekt/SARIF steps, and enable the signing plugin in the build

Build:
- Add the 'signing' Gradle plugin to enable artifact signing in the build.gradle

CI:
- Replace local maven publish step with Gradle publishToMavenCentral using Maven Central credentials and GPG signing, and bump version to 2.3.5.1
- Remove commented-out Detekt lint and SARIF upload actions from the CI workflow

</details>